### PR TITLE
`master` branch should be using `master` version number and not `8.0.0`

### DIFF
--- a/project.spdx.yml
+++ b/project.spdx.yml
@@ -1,7 +1,7 @@
 SPDXID: "SPDXRef-DOCUMENT"
 spdxVersion: "SPDX-2.2"
 creationInfo:
-  created: "2023-06-06T17:06:48Z"
+  created: "2021-11-26T19:14:02Z"
   creators:
   - "Organization: Sequent Tech Inc."
   - "Person: Eduardo Robles"
@@ -15,13 +15,13 @@ packages:
 - SPDXID: "SPDXRef-Package-mixnet"
   summary: "Sequent MixNet, a fork of Verificatum MixNet."
   copyrightText: "Copyright 2008-2021 Douglas Wikstrom and Sequent Tech Inc"
-  downloadLocation: "git+https://github.com/sequentech/mixnet.git@8.0.0"
+  downloadLocation: "git+https://github.com/sequentech/mixnet.git@master"
   filesAnalyzed: false
   homepage: "https://github.com/sequentech/mixnet"
   licenseConcluded:  "NOASSERTION"
   licenseDeclared: "GPL-3.0-only"
   name: "mixnet"
-  versionInfo: "8.0.0"
+  versionInfo: "master"
 - SPDXID: "SPDXRef-Package-libgmp"
   description: "Multiprecision arithmetic library."
   copyrightText: "Copyright (c) 1991 - 2021, Steve M. Robbins <smr@debian.org>, Philipp Matthias Hahn <pmhahn@debian.org>"


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/136

Revert "Release for version 8.0.0"

This reverts commit c89c44afb59b7146ed963cba0815afd9f4bb7762.